### PR TITLE
feat: [윤희지] main의 home을 HomeScreen으로 변경  [NEXT-PAGE-APP-UI-1]

### DIFF
--- a/next-page-flutter/app/lib/home-screen.dart
+++ b/next-page-flutter/app/lib/home-screen.dart
@@ -1,6 +1,8 @@
-import 'package:basic/novel/novel-detail-screen.dart';
-import 'package:basic/novel/scroll-novel-viewer-screen.dart';
+
+import 'package:app/member/screens/sign_in_screen.dart';
 import 'package:flutter/material.dart';
+import 'member/screens/sign_up_screen.dart';
+import 'novel/scroll-novel-viewer-screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -28,10 +30,19 @@ class _HomeScreenState extends State<HomeScreen> {
               child: Text("리스트뷰 방식 읽기")),
           TextButton(
               onPressed: () {
-                Navigator.push(context, MaterialPageRoute(builder: (context) => NovelDetailScreen()));
+               // Navigator.push(context, MaterialPageRoute(builder: (context) => NovelDetailScreen()));
               },
               child: Text("소설 상세보기 페이지")),
-
+          TextButton(
+              onPressed: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) => SignInScreen()));
+              },
+              child: Text("로그인 페이지")),
+          TextButton(
+              onPressed: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) => SignUpScreen()));
+              },
+              child: Text("회원가입 페이지")),
         ],
       ),
     );

--- a/next-page-flutter/app/lib/main.dart
+++ b/next-page-flutter/app/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:app/home-screen.dart';
 import 'package:app/member/screens/sign_in_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,7 +19,7 @@ class MyApp extends StatelessWidget {
               systemOverlayStyle: SystemUiOverlayStyle.dark
           )
       ),
-      home: SignInScreen(),
+      home: HomeScreen(),
       routes: {
         "sign-in": (context) => SignInScreen(),
       }

--- a/next-page-flutter/app/lib/member/api/responses.dart
+++ b/next-page-flutter/app/lib/member/api/responses.dart
@@ -1,0 +1,5 @@
+class SignInResponse {
+  bool result;
+
+  SignInResponse(this.result);
+}


### PR DESCRIPTION
- main.dart의 home을 HomeScreen()으로 변경
- HomeScreen 내부에 로그인, 회원가입 페이지로 이동하는 버튼 추가