### PR TITLE
fix: [윤희지] 포인트 충전 페이지 뒤로가기 로직 변경[NEXT-PAGE-APP-UI-28]

### DIFF
--- a/next-page-flutter/app/lib/member/api/requests.dart
+++ b/next-page-flutter/app/lib/member/api/requests.dart
@@ -12,3 +12,9 @@ class SignUpRequest {
 
   SignUpRequest(this.email, this.password, this.nickName);
 }
+
+class MemberPointRequest {
+  int memberId;
+
+  MemberPointRequest(this.memberId);
+}

--- a/next-page-flutter/app/lib/member/widgets/forms/sign_in_form.dart
+++ b/next-page-flutter/app/lib/member/widgets/forms/sign_in_form.dart
@@ -1,13 +1,13 @@
 
-import 'package:app/member/api/SpringMemberApi.dart';
-import 'package:app/member/api/requests.dart';
-import 'package:app/novel/screens/novel_detail_screen.dart';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../custom_bottom_appbar.dart';
+import '../../../novel/screens/novel_detail_screen.dart';
+import '../../../widgets/custom_bottom_appbar.dart';
+import '../../api/spring_member_api.dart';
+import '../../api/requests.dart';
 import '../../api/responses.dart';
 import '../../utility/custom_text_style.dart';
 import '../buttons/navigation_btn.dart';
@@ -89,9 +89,6 @@ class _SignInFormState extends State <SignInForm>{
                               if(_formKey.currentState!.validate()) {
                                 signInResponse = await SpringMemberApi().signIn(SignInRequest(email, password));
                                 if(signInResponse.result == true) {
-                                  // spring서버가 응답한 token값을 prefs로 디스크에 저장
-                                  final prefs = await SharedPreferences.getInstance();
-                                  await prefs.setString('userToken', signInResponse.userToken);
                                   if(widget.fromWhere == myIdx) {
                                     Navigator.pushAndRemoveUntil(
                                         context,
@@ -114,7 +111,7 @@ class _SignInFormState extends State <SignInForm>{
                                   }
 
                                 } else {
-                                  showResultDialog(context, "알림", signInResponse.userToken.toString());
+                                  showResultDialog(context, "알림", "이메일 혹은 비밀번호가 올바르지 않습니다.");
                                 }
                               } else {
                                 showResultDialog(context, "알림", "유효한 값을 모두 입력해주세요!");

--- a/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
@@ -108,7 +108,7 @@ class _MypageScreenState extends State<MypageScreen> {
                       title: Text("보유 포인트: $currentPoint p"),
                       //title: Text("보유포인트 0 p"),
                       trailing: ElevatedButton(
-                          onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (context) => PointChargeScreen())),
+                          onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (context) => PointChargeScreen(fromWhere: fromMy,))),
                           child: Text('충전하기'))),
                   ),
                   const Card(

--- a/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
@@ -1,7 +1,6 @@
+
 import 'package:app/member/screens/sign_in_screen.dart';
-import 'package:app/member/utility/user_data_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../point/screens/point_charge_screen.dart';
@@ -14,9 +13,11 @@ class MypageScreen extends StatefulWidget {
 }
 
 class _MypageScreenState extends State<MypageScreen> {
-  late bool? _loginState;
+  bool _loginState = false;
   bool _isLoading = true;
   final int fromMy = 4;
+  late String nickname;
+  late int currentPoint;
 
   @override
   void initState() {
@@ -32,9 +33,12 @@ class _MypageScreenState extends State<MypageScreen> {
   void _asyncMethod() async {
     var prefs = await SharedPreferences.getInstance();
     String? userToken = prefs.getString('userToken');
+
     if (userToken != null) {
       setState(() {
         _loginState = true;
+        nickname = prefs.getString('nickname')!;
+        currentPoint = prefs.getInt('point')!;
       });
     } else {
       setState(() {
@@ -97,13 +101,12 @@ class _MypageScreenState extends State<MypageScreen> {
               padding: EdgeInsets.all(16.0),
               child: ListView(
                 children: [
-                  // 로그인한 사용자의 닉네임 표시할 예정
-                  // 로그인한 사용자의 정보(닉네임, 포인트)를 언제 불러올지 고민,,
-                  Text("김철수님", style: TextStyle(fontSize: 15)),
+                  Text(nickname + "님", style: TextStyle(fontSize: 20)),
                   SizedBox(height: size.height * 0.01,),
                   Card(
                     child: ListTile(
-                      title: Text("보유 포인트: ${context.watch<UserDataProvider>().point} p"),
+                      title: Text("보유 포인트: $currentPoint p"),
+                      //title: Text("보유포인트 0 p"),
                       trailing: ElevatedButton(
                           onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (context) => PointChargeScreen())),
                           child: Text('충전하기'))),
@@ -147,7 +150,7 @@ class _MypageScreenState extends State<MypageScreen> {
                                     onPressed: () async {
                                       var prefs = await SharedPreferences
                                           .getInstance();
-                                      prefs.remove('userToken');
+                                      prefs.clear();
                                       setState(() {
                                         _loginState = false;
                                       });

--- a/next-page-flutter/app/lib/point/point_option.dart
+++ b/next-page-flutter/app/lib/point/point_option.dart
@@ -1,6 +1,0 @@
-class PointOption {
-  late int point;
-  late int price;
-
-  PointOption({required this.point, required this.price});
-}


### PR DESCRIPTION
spring의 로그인 시스템이 토큰 이외의 유저 데이터들도 함께 리턴하도록 변경되어 유저 데이터를 보여주는 앱 UI들의 내부 코드를 변경함.
**<변경>**
- 로그인 form의 로그인 버튼(토큰 저장 로직 삭제)
- 마이페이지 UI(닉네임, 포인트)
- 로그인 요청 api(res의 유저 데이터를 shared prefereces로 로컬에 저장

**<추가>**
- 포인트 충전 후의 유저 포인트 정보를 요청하는 api
- 포인트 충전 페이지 위젯에 파라미터 추가, 앱바 뒤로 가기 버튼 기능 추가 