### PR TITLE
feat: [윤희지] 회원정보 변경 페이지 구현 완료 [NEXT-PAGE-APP-UI-7]

### DIFF
--- a/next-page-flutter/app/lib/member/api/requests.dart
+++ b/next-page-flutter/app/lib/member/api/requests.dart
@@ -25,3 +25,10 @@ class NicknameModifyRequest {
 
   NicknameModifyRequest(this.memberId, this.newNickname);
 }
+
+class PasswordModifyRequest {
+  int memberId;
+  String newPassword;
+
+  PasswordModifyRequest(this.memberId, this.newPassword);
+}

--- a/next-page-flutter/app/lib/member/api/requests.dart
+++ b/next-page-flutter/app/lib/member/api/requests.dart
@@ -18,3 +18,10 @@ class MemberPointRequest {
 
   MemberPointRequest(this.memberId);
 }
+
+class NicknameModifyRequest {
+  int memberId;
+  String newNickname;
+
+  NicknameModifyRequest(this.memberId, this.newNickname);
+}

--- a/next-page-flutter/app/lib/member/api/spring_member_api.dart
+++ b/next-page-flutter/app/lib/member/api/spring_member_api.dart
@@ -116,6 +116,26 @@ class SpringMemberApi {
     }
   }
 
+  Future<String> modifyNickname(NicknameModifyRequest request) async {
+    var data = { 'memberId' : request.memberId, 'reNickName' : request.newNickname };
+    var body = json.encode(data);
+    debugPrint(body);
+
+    var response = await http.post(
+      Uri.http(httpUri, '/member/modify-nickName'),
+      headers: {"Content-Type": "application/json"},
+      body: body,
+    );
+
+    if (response.statusCode == 200) {
+      debugPrint("통신 확인");
+      return response.body.toString();
+    } else {
+      throw Exception("통신 실패");
+    }
+  }
+
+
   Future<int> lookUpUserPoint(MemberPointRequest request) async {
     var data = { 'memberId': request.memberId };
     var body = json.encode(data);

--- a/next-page-flutter/app/lib/member/api/spring_member_api.dart
+++ b/next-page-flutter/app/lib/member/api/spring_member_api.dart
@@ -135,6 +135,26 @@ class SpringMemberApi {
     }
   }
 
+  Future<bool> modifyPassword(PasswordModifyRequest request) async {
+    var data = { 'memberId' : request.memberId, 'newPassword' : request.newPassword };
+    var body = json.encode(data);
+    debugPrint(body);
+
+    var response = await http.post(
+      Uri.http(httpUri, '/member/modify-password'),
+      headers: {"Content-Type": "application/json"},
+      body: body,
+    );
+
+    if (response.statusCode == 200) {
+      debugPrint("통신 확인");
+      return json.decode(response.body);
+    } else {
+      debugPrint("통신 실패");
+      return false;
+    }
+  }
+
 
   Future<int> lookUpUserPoint(MemberPointRequest request) async {
     var data = { 'memberId': request.memberId };

--- a/next-page-flutter/app/lib/member/widgets/forms/sign_in_form.dart
+++ b/next-page-flutter/app/lib/member/widgets/forms/sign_in_form.dart
@@ -82,7 +82,7 @@ class _SignInFormState extends State <SignInForm>{
                     SizedBox(height: size.height * 0.1),
                     EmailTextField(controller: emailController),
                     SizedBox(height: size.height * 0.03),
-                    PasswordTextField(controller: passwordController),
+                    PasswordTextField(controller: passwordController, label: '비밀번호'),
                     SizedBox(height: size.height * 0.03),
                     ElevatedButton(
                         style: ElevatedButton.styleFrom(

--- a/next-page-flutter/app/lib/member/widgets/forms/sign_up_form.dart
+++ b/next-page-flutter/app/lib/member/widgets/forms/sign_up_form.dart
@@ -1,17 +1,18 @@
 
-import 'package:app/member/api/SpringMemberApi.dart';
-import 'package:app/member/api/requests.dart';
-import 'package:app/member/utility/custom_text_style.dart';
-import 'package:app/member/widgets/alerts/custom_result_alert.dart';
-import 'package:app/member/widgets/alerts/custom_result_and_push_alert.dart';
-import 'package:app/member/widgets/text_fields/email_text_field.dart';
-import 'package:app/member/widgets/text_fields/nickname_text_field.dart';
-import 'package:app/member/widgets/text_fields/password_text_field.dart';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../api/spring_member_api.dart';
+import '../../api/requests.dart';
+import '../../utility/custom_text_style.dart';
+import '../alerts/custom_result_alert.dart';
+import '../alerts/custom_result_and_push_alert.dart';
+import '../text_fields/email_text_field.dart';
+import '../text_fields/nickname_text_field.dart';
 import '../text_fields/password_check_text_field.dart';
+import '../text_fields/password_text_field.dart';
 
 
 class SignUpForm extends StatefulWidget {
@@ -25,7 +26,7 @@ class SignUpFormState extends State <SignUpForm>{
   final _formKey = GlobalKey<FormState>();
 
   late String email;
-  late String password;
+  String password = ''; //LateInitializationError 때문에 late -> ''값으로 초기화
   late String nickname;
 
   late TextEditingController emailController = TextEditingController();
@@ -86,10 +87,11 @@ class SignUpFormState extends State <SignUpForm>{
                                 if(emailController.text.isEmpty) {
                                   _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: '내용을 입력해주세요!'));
                                 } else {
-                                emailPass = await SpringMemberApi().emailCheck(email);
-                                debugPrint(emailPass.toString());
-                                _showDupCheckResult(context, emailPass, '이메일'); }
-                                },
+                                    emailPass = await SpringMemberApi().emailCheck(email);
+                                    debugPrint(emailPass.toString());
+                                    _showDupCheckResult(context, emailPass, '이메일');
+                                }
+                              },
                               child: Text("중복 확인"),)
                           ],
                         ),
@@ -97,7 +99,7 @@ class SignUpFormState extends State <SignUpForm>{
                       // 닉네임 입력 텍스트 필드 & 중복 확인 버튼
                       Row(
                         children: [
-                          Expanded( child: NicknameTextField(controller: nicknameController)),
+                          Expanded( child: NicknameTextField(controller: nicknameController, label: '닉네임',)),
                           ElevatedButton(
                             onPressed: () async {
                               if(nicknameController.text.isEmpty) {
@@ -111,9 +113,9 @@ class SignUpFormState extends State <SignUpForm>{
                         ],
                       ),
                       SizedBox(height: size.height * 0.03),
-                      PasswordTextField(controller: passwordController),
+                      PasswordTextField(controller: passwordController, label: '비밀번호',),
                       SizedBox(height: size.height * 0.03),
-                      PasswordCheckTextField(),
+                      PasswordCheckTextField(password: password),
                       SizedBox(height: size.height * 0.03),
                       // 회원가입 버튼
                       ElevatedButton(

--- a/next-page-flutter/app/lib/member/widgets/text_fields/nickname_text_field.dart
+++ b/next-page-flutter/app/lib/member/widgets/text_fields/nickname_text_field.dart
@@ -5,8 +5,10 @@ import '../../utility/check_validate.dart';
 import '../forms/sign_up_form.dart';
 
 class NicknameTextField extends StatefulWidget {
-  const NicknameTextField({Key? key, required this.controller}) : super(key: key);
+  const NicknameTextField({Key? key, required this.controller, required this.label}) : super(key: key);
   final TextEditingController controller;
+  // 텍스트 필드 라벨 parameter 추가
+  final String label;
 
   @override
   State<NicknameTextField> createState() => _NicknameTextFieldState();
@@ -22,7 +24,7 @@ class _NicknameTextFieldState extends State<NicknameTextField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text("닉네임"),
+        Text(widget.label),
         SizedBox(height: size.height * 0.01,),
         TextFormField(
           controller: widget.controller,

--- a/next-page-flutter/app/lib/member/widgets/text_fields/password_check_text_field.dart
+++ b/next-page-flutter/app/lib/member/widgets/text_fields/password_check_text_field.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import '../forms/sign_up_form.dart';
-
 class PasswordCheckTextField extends StatefulWidget {
-  const PasswordCheckTextField({Key? key}) : super(key: key);
+  const PasswordCheckTextField({Key? key, required this.password}) : super(key: key);
+  final String password;
 
   @override
   State<PasswordCheckTextField> createState() => _PasswordCheckTextFieldState();
@@ -14,7 +13,6 @@ class _PasswordCheckTextFieldState extends State<PasswordCheckTextField> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
-    SignUpFormState? form = context.findAncestorStateOfType<SignUpFormState>();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -23,7 +21,7 @@ class _PasswordCheckTextFieldState extends State<PasswordCheckTextField> {
         SizedBox(height: size.height * 0.01),
         TextFormField(
           obscureText: true,
-          validator: (value) => value != form?.password ? "비밀번호가 일치하지 않습니다." : null,
+          validator: (value) => value != widget.password ? "비밀번호가 일치하지 않습니다." : null,
           autovalidateMode: AutovalidateMode.onUserInteraction,
           decoration: InputDecoration(
             prefixIcon: Icon(Icons.lock),

--- a/next-page-flutter/app/lib/member/widgets/text_fields/password_text_field.dart
+++ b/next-page-flutter/app/lib/member/widgets/text_fields/password_text_field.dart
@@ -4,8 +4,9 @@ import 'package:flutter/material.dart';
 import '../../utility/check_validate.dart';
 
 class PasswordTextField extends StatefulWidget {
-  const PasswordTextField({Key? key, required this.controller}) : super(key: key);
+  const PasswordTextField({Key? key, required this.controller, required this.label}) : super(key: key);
   final TextEditingController controller;
+  final String label;
 
   @override
   State<PasswordTextField> createState() => _PasswordTextFieldState();
@@ -19,7 +20,7 @@ class _PasswordTextFieldState extends State<PasswordTextField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text("비밀번호"),
+        Text(widget.label),
         SizedBox(height: size.height * 0.01),
         TextFormField(
           controller: widget.controller,

--- a/next-page-flutter/app/lib/mypage/screens/my_info_modify_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/my_info_modify_screen.dart
@@ -1,10 +1,12 @@
 
 import 'package:app/member/api/spring_member_api.dart';
 import 'package:app/member/widgets/alerts/custom_result_alert.dart';
+import 'package:app/mypage/screens/password_modify_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../widgets/custom_bottom_appbar.dart';
+import 'nickname_modify_screen.dart';
 
 class MyInfoModifyScreen extends StatefulWidget {
   const MyInfoModifyScreen({Key? key}) : super(key: key);
@@ -15,6 +17,7 @@ class MyInfoModifyScreen extends StatefulWidget {
 
 class _MyInfoModifyScreenState extends State<MyInfoModifyScreen> {
   String email = '';
+  final int myIdx = 4;
 
   @override
   void initState() {
@@ -36,6 +39,17 @@ class _MyInfoModifyScreenState extends State<MyInfoModifyScreen> {
       appBar: AppBar(
           elevation: 0,
           title: Text("회원 정보 변경"),
+          leading: IconButton(
+            icon: Icon(Icons.arrow_back),
+            onPressed: () {
+              Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                      builder: (BuildContext context) =>
+                          CustomBottomAppbar(routeIndex: myIdx,)),
+                      (route) => false);
+            },
+          ),
       ),
       body: Padding(
           padding: EdgeInsets.all(0.0),
@@ -46,23 +60,26 @@ class _MyInfoModifyScreenState extends State<MyInfoModifyScreen> {
                         title: Text("로그인 계정 정보"),
                         subtitle: Text(email),
                       ),
-                      const Divider(),
-                      const ListTile(
+                      const Divider(thickness: 1, height: 1,),
+                      ListTile(
+                        contentPadding: EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 5.0),
                         title: Text("닉네임 변경하기"),
                         trailing: Icon(Icons.arrow_forward_ios_rounded),
-                        // onTap: () => Navigator.push(context,
-                        //     MaterialPageRoute(builder: (context) => NicknameModifyScreen())),
+                        onTap: () => Navigator.push(context,
+                            MaterialPageRoute(builder: (context) => NicknameModifyScreen())),
                       ),
-                      const Divider(),
-                      const ListTile(
+                      const Divider(thickness: 1, height: 1,),
+                       ListTile(
+                        contentPadding: EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 5.0),
                         title: Text("비밀번호 변경하기"),
                         trailing: Icon(Icons.arrow_forward_ios_rounded),
-                        // onTap: () => Navigator.push(context,
-                        //     MaterialPageRoute(builder: (context) => //비밀번호 변경 페이지)),
+                        onTap: () => Navigator.push(context,
+                            MaterialPageRoute(builder: (context) => PasswordModifyScreen())),
                       ),
-                      const Divider(),
+                      const Divider(thickness: 1, height: 1,),
                       ListTile(
-                        title: Text("회원 탈퇴"),
+                        contentPadding: EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 5.0),
+                        title: Text("회원 탈퇴", style: TextStyle(color: Colors.grey),),
                         onTap: () {
                           _showAlertDialog(context,
                               AlertDialog(
@@ -96,6 +113,7 @@ class _MyInfoModifyScreenState extends State<MyInfoModifyScreen> {
                           ));
                         }
                       ),
+                      const Divider(thickness: 1, height: 1,),
                     ],
                   )
           )

--- a/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/mypage_screen.dart
@@ -81,7 +81,7 @@ class _MypageScreenState extends State<MypageScreen> {
                         onPressed: () async {
                           Navigator.push(
                               context,
-                              MaterialPageRoute(builder: (context) => SignInScreen(fromWhere: fromMy, novel: "none")));
+                              MaterialPageRoute(builder: (context) => SignInScreen(fromWhere: fromMy, novel: "none", routeIndex: 99,)));
                           },
                         child: Text('로그인'))),
                 ),
@@ -99,7 +99,6 @@ class _MypageScreenState extends State<MypageScreen> {
                   Card(
                     child: ListTile(
                       title: Text("보유 포인트: $currentPoint p"),
-                      //title: Text("보유포인트 0 p"),
                       trailing: ElevatedButton(
                           onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (context) => PointChargeScreen(fromWhere: fromMy,))),
                           child: Text('충전하기'))),

--- a/next-page-flutter/app/lib/mypage/screens/nickname_modify_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/nickname_modify_screen.dart
@@ -1,0 +1,118 @@
+import 'package:app/member/api/requests.dart';
+import 'package:app/member/widgets/text_fields/nickname_text_field.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../member/api/spring_member_api.dart';
+import '../../member/widgets/alerts/custom_result_alert.dart';
+
+class NicknameModifyScreen extends StatefulWidget{
+  const NicknameModifyScreen({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => NicknameModifyScreenState();
+}
+
+class NicknameModifyScreenState extends State<NicknameModifyScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late int memberId;
+  late String newNickname;
+  late String currentNickname;
+
+  late TextEditingController nicknameController = TextEditingController();
+
+  final String modifySuccess = "닉네임 변경 되었습니다.";
+  final String dupNickname = "중복된 닉네임 입니다.";
+  final String noSuchUser = "회원정보를 찾을수 없습니다.";
+
+  @override
+  void initState() {
+    _asyncMethod();
+    nicknameController.addListener(() {
+      newNickname = nicknameController.text;
+    });
+
+    super.initState();
+  }
+
+  void _asyncMethod() async {
+    var prefs = await SharedPreferences.getInstance();
+    setState(() {
+      memberId = prefs.getInt('userId')!;
+      currentNickname = prefs.getString('nickname')!;
+    });
+  }
+
+  @override
+  void dispose() {
+    nicknameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Size size = MediaQuery.of(context).size;
+    return GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text('닉네임 변경'),
+          ),
+          body: Form(
+            key: _formKey,
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                children: [
+                  Container(
+                    color: Colors.grey.shade100,
+                    child: ListTile(
+                        title: Text("현재 닉네임"),
+                        subtitle: Text(currentNickname, textAlign: TextAlign.end, style: TextStyle(fontSize: 20)),
+                    )
+                  ),
+                  SizedBox(height: size.height * 0.01,),
+                  ListTile(
+                    title: NicknameTextField(controller: nicknameController, label: '새로운 닉네임',),
+                  ),
+                  SizedBox(height: size.height * 0.03,),
+                  ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                          minimumSize: Size(size.width * 0.4, size.height * 0.05)),
+                      onPressed: () async {
+                        if(_formKey.currentState!.validate()) {
+                          var result = await SpringMemberApi().modifyNickname(NicknameModifyRequest(memberId, newNickname));
+                          debugPrint('result: ' + result);
+                          if(result == modifySuccess) {
+                            var prefs = await SharedPreferences.getInstance();
+                            prefs.setString('nickname', newNickname);
+                            setState(() {
+                              currentNickname = newNickname;
+                            });
+                            _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: result));
+                          } else if(result == noSuchUser) {
+                            _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: result));
+                          } else if(result == dupNickname) {
+                            _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: result));
+                          }
+                        } else {
+                          _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: '유효한 닉네임을 입력하세요!'));
+                        }
+                      },
+                      child: Text('닉네임 변경하기'))
+                  ]),
+              )
+            ),
+          )
+    );
+  }
+
+  void _showAlertDialog(BuildContext context, Widget alert) {
+    showDialog(
+        context: context,
+        builder: (BuildContext context) => alert);
+  }
+}

--- a/next-page-flutter/app/lib/mypage/screens/password_modify_screen.dart
+++ b/next-page-flutter/app/lib/mypage/screens/password_modify_screen.dart
@@ -1,0 +1,99 @@
+import 'package:app/member/api/requests.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../member/api/spring_member_api.dart';
+import '../../member/widgets/alerts/custom_result_alert.dart';
+import '../../member/widgets/text_fields/password_check_text_field.dart';
+import '../../member/widgets/text_fields/password_text_field.dart';
+
+class PasswordModifyScreen extends StatefulWidget{
+  const PasswordModifyScreen({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => PasswordModifyScreenState();
+}
+
+class PasswordModifyScreenState extends State<PasswordModifyScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late int memberId;
+  String newPassword = '';
+
+  late TextEditingController newPasswordController = TextEditingController();
+
+  @override
+  void initState() {
+    _asyncMethod();
+    newPasswordController.addListener(() {
+      newPassword = newPasswordController.text;
+    });
+    super.initState();
+  }
+
+  void _asyncMethod() async {
+    var prefs = await SharedPreferences.getInstance();
+    setState(() {
+      memberId = prefs.getInt('userId')!;
+    });
+  }
+
+  @override
+  void dispose() {
+    newPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Size size = MediaQuery.of(context).size;
+    return GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text('비밀번호 변경'),
+          ),
+          body: Form(
+            key: _formKey,
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                children: [
+                  ListTile(
+                    title: PasswordTextField(controller: newPasswordController, label: '새 비밀번호',),
+                  ),
+                  SizedBox(height: size.height * 0.03,),
+                  ListTile(
+                    title: PasswordCheckTextField(password: newPassword,)
+                  ),
+                  SizedBox(height: size.height * 0.01,),
+                  ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                          minimumSize: Size(size.width * 0.4, size.height * 0.05)),
+                      onPressed: () async {
+                        if(_formKey.currentState!.validate()) {
+                          bool result = await SpringMemberApi().modifyPassword(PasswordModifyRequest(memberId, newPassword));
+                          debugPrint('result: ' + result.toString());
+                          if(result) {
+                             _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: '비밀번호가 변경되었습니다.'));
+                          } else { _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: '통신 문제로 비밀번호 변경에 실패했습니다.')); }
+                        } else {
+                          _showAlertDialog(context, CustomResultAlert(title: '알림', alertMsg: '유효한 값을 입력해주세요!'));
+                        }
+                      },
+                      child: Text('비밀번호 변경하기'))
+                  ]),
+              )
+            ),
+          )
+    );
+  }
+
+  void _showAlertDialog(BuildContext context, Widget alert) {
+    showDialog(
+        context: context,
+        builder: (BuildContext context) => alert);
+  }
+}


### PR DESCRIPTION
비밀번호 변경 페이지가 처음 빌드 됐을 때 비밀번호 확인 text field의 유효성 검사가 바로 적용이 안되는 이슈가 있음.
포커스를 해제하면 유효성 검사가 잘 동작함.

+ 비밀번호 확인 text field의 경우 유효성 검사를 위해 password text field의 값을 파라미터로 받아오는 방식으로 변경.